### PR TITLE
Tweak a few minor bits

### DIFF
--- a/3.0.4/Dockerfile
+++ b/3.0.4/Dockerfile
@@ -1,21 +1,21 @@
-FROM tomcat:8.0
+FROM tomcat:8.0-jre7
 
-#Environment variables
-ENV GN_VERSION 3.0.4
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
 ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC"
 
+#Environment variables
+ENV GN_VERSION 3.0.4
+ENV GN_DOWNLOAD_MD5 b50d0c63c0e4750d7ea87d4853fa4cdb
+
 WORKDIR $CATALINA_HOME/webapps
 
-RUN curl -fSL -o geonetwork.war.MD5 https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war.MD5/download && \ 
-    curl -fSL -o $GN_FILE \
+RUN curl -fSL -o $GN_FILE \
      https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war/download && \
-     echo "$(cat geonetwork.war.MD5) *$GN_FILE" | md5sum -c
-
-RUN  mkdir -p $CATALINA_HOME/webapps/geonetwork && \
-        unzip -e $CATALINA_HOME/webapps/$GN_FILE -d $CATALINA_HOME/webapps/geonetwork && \
-        rm geonetwork.war
+     echo "$GN_DOWNLOAD_MD5 *$GN_FILE" | md5sum -c && \
+     mkdir -p geonetwork && \
+     unzip -e $GN_FILE -d geonetwork && \
+     rm $GN_FILE
 
 #Set geonetwork data dir
 COPY ./docker-entrypoint.sh /entrypoint.sh

--- a/3.0.4/docker-entrypoint.sh
+++ b/3.0.4/docker-entrypoint.sh
@@ -3,13 +3,10 @@ set -e
 
 if [ "$1" = 'catalina.sh' ]; then
 
- mkdir -p "$DATA_DIR"
+	mkdir -p "$DATA_DIR"
 
- #Set geonetwork data dir
- sed -i '$d' /usr/local/tomcat/bin/setclasspath.sh
- echo "CATALINA_OPTS=\"\$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR\"" >> /usr/local/tomcat/bin/setclasspath.sh
- echo "fi" >> /usr/local/tomcat/bin/setclasspath.sh
-
+	#Set geonetwork data dir
+	export CATALINA_OPTS="$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR"
 fi
 
 exec "$@"

--- a/3.0.4/postgres/Dockerfile
+++ b/3.0.4/postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM geonetwork:3.0.4
 
 RUN apt-get update && apt-get install -y postgresql-client && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 #Set PostgreSQL as default GN DB
 RUN sed -i -e 's#<import resource="../config-db/h2.xml"/>#<!--<import resource="../config-db/h2.xml"/> -->#g' $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-node/srv.xml
@@ -12,3 +12,5 @@ COPY ./jdbc.properties $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-db/jdbc.
 #Initializing database & connection string for GN
 COPY ./docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["catalina.sh", "run"]

--- a/3.0.4/postgres/docker-entrypoint.sh
+++ b/3.0.4/postgres/docker-entrypoint.sh
@@ -1,74 +1,51 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Found db container linked
-
-
-
-Found no db container linked. You must set POSTGRES_DB_HOST, if you want to connect to a remote DB
-
-
-
-
-
-
-db host:
-
-
-
-
-
-
-
-db port:
-
-
-you must set POSTGRES_DB_USERNAME and POSTGRES_DB_PASSWORD
-
-
-
-
-
-
-
-
-
-
-
-database  exists; do nothing
-
-
-
-
-
-database  exists; do nothing
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+#!/bin/bash
+set -e
+
+if [ "$1" = 'catalina.sh' ]; then
+
+	mkdir -p "$DATA_DIR"
+
+	#Set geonetwork data dir
+	export CATALINA_OPTS="$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR"
+
+	#Setting host (use $POSTGRES_DB_HOST if it's set, otherwise use "postgres")
+	db_host="${POSTGRES_DB_HOST:-postgres}"
+	echo "db host: $db_host"
+
+	#Setting port
+	db_port="${POSTGRES_DB_PORT:-5432}"
+	echo "db port: $db_port"
+
+	if [ -z "$POSTGRES_DB_USERNAME" ] || [ -z "$POSTGRES_DB_PASSWORD" ]; then
+		echo >&2 "you must set POSTGRES_DB_USERNAME and POSTGRES_DB_PASSWORD"
+		exit 1
+	fi
+
+	db_admin="admin"
+	db_gn="geonetwork"
+
+	#Create databases, if they do not exist yet (http://stackoverflow.com/a/36591842/433558)
+	echo  "$db_host:$db_port:*:$POSTGRES_DB_USERNAME:$POSTGRES_DB_PASSWORD" > ~/.pgpass
+	chmod 0600 ~/.pgpass
+	for db_name in "$db_admin" "$db_gn"; do
+		if psql -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -tqc "SELECT 1 FROM pg_database WHERE datname = '$db_name'" | grep -q 1; then
+			echo "database '$db_name' exists; skipping createdb"
+		else
+			createdb -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -O "$POSTGRES_DB_USERNAME" "$db_name"
+		fi
+	done
+	rm ~/.pgpass
+
+	#Write connection string for GN
+	sed -ri '/^jdbc[.](username|password|database|host|port)=/d' "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.username=$POSTGRES_DB_USERNAME" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.password=$POSTGRES_DB_PASSWORD" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.database=$db_gn" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.host=$db_host" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.port=$db_port" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+
+	#Fixing an hardcoded port on the connection string (bug fixed on development branch)
+	sed -i -e 's#5432#${jdbc.port}#g' $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-db/postgres.xml
+fi
+
+exec "$@"

--- a/3.0.5/Dockerfile
+++ b/3.0.5/Dockerfile
@@ -1,21 +1,21 @@
-FROM tomcat:8.0
+FROM tomcat:8.0-jre7
 
-#Environment variables
-ENV GN_VERSION 3.0.5
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
 ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC"
 
+#Environment variables
+ENV GN_VERSION 3.0.5
+ENV GN_DOWNLOAD_MD5 1e77c39de4ad156cc9b3c2b033cab359
+
 WORKDIR $CATALINA_HOME/webapps
 
-RUN curl -fSL -o geonetwork.war.MD5 https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war.MD5/download && \ 
-    curl -fSL -o $GN_FILE \
-      https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war/download && \
-      echo "$(cat geonetwork.war.MD5) *$GN_FILE" | md5sum -c
-
-RUN  mkdir -p $CATALINA_HOME/webapps/geonetwork && \
-        unzip -e $CATALINA_HOME/webapps/$GN_FILE -d $CATALINA_HOME/webapps/geonetwork && \
-        rm geonetwork.war && rm geonetwork.war.MD5
+RUN curl -fSL -o $GN_FILE \
+     https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war/download && \
+     echo "$GN_DOWNLOAD_MD5 *$GN_FILE" | md5sum -c && \
+     mkdir -p geonetwork && \
+     unzip -e $GN_FILE -d geonetwork && \
+     rm $GN_FILE
 
 #Set geonetwork data dir
 COPY ./docker-entrypoint.sh /entrypoint.sh

--- a/3.0.5/docker-entrypoint.sh
+++ b/3.0.5/docker-entrypoint.sh
@@ -3,13 +3,10 @@ set -e
 
 if [ "$1" = 'catalina.sh' ]; then
 
- mkdir -p "$DATA_DIR"
+	mkdir -p "$DATA_DIR"
 
- #Set geonetwork data dir
- sed -i '$d' /usr/local/tomcat/bin/setclasspath.sh
- echo "CATALINA_OPTS=\"\$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR\"" >> /usr/local/tomcat/bin/setclasspath.sh
- echo "fi" >> /usr/local/tomcat/bin/setclasspath.sh
-
+	#Set geonetwork data dir
+	export CATALINA_OPTS="$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR"
 fi
 
 exec "$@"

--- a/3.0.5/postgres/Dockerfile
+++ b/3.0.5/postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM geonetwork:3.0.5
 
 RUN apt-get update && apt-get install -y postgresql-client && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 #Set PostgreSQL as default GN DB
 RUN sed -i -e 's#<import resource="../config-db/h2.xml"/>#<!--<import resource="../config-db/h2.xml"/> -->#g' $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-node/srv.xml
@@ -12,3 +12,5 @@ COPY ./jdbc.properties $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-db/jdbc.
 #Initializing database & connection string for GN
 COPY ./docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["catalina.sh", "run"]

--- a/3.2.0/Dockerfile
+++ b/3.2.0/Dockerfile
@@ -1,21 +1,21 @@
-FROM tomcat:8-jre8
+FROM tomcat:8.0-jre8
 
-#Environment variables
-ENV GN_VERSION 3.2.0
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
 ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC"
 
+#Environment variables
+ENV GN_VERSION 3.2.0
+ENV GN_DOWNLOAD_MD5 87a84ffb3fbbd662d595c08e1a7fdff2
+
 WORKDIR $CATALINA_HOME/webapps
 
-RUN curl -fSL -o geonetwork.war.MD5 https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war.MD5/download && \ 
-    curl -fSL -o $GN_FILE \
+RUN curl -fSL -o $GN_FILE \
      https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${GN_VERSION}/geonetwork.war/download && \
-     echo "$(cat geonetwork.war.MD5) *$GN_FILE" | md5sum -c
-
-RUN  mkdir -p $CATALINA_HOME/webapps/geonetwork && \
-        unzip -e $CATALINA_HOME/webapps/$GN_FILE -d $CATALINA_HOME/webapps/geonetwork && \
-        rm geonetwork.war
+     echo "$GN_DOWNLOAD_MD5 *$GN_FILE" | md5sum -c && \
+     mkdir -p geonetwork && \
+     unzip -e $GN_FILE -d geonetwork && \
+     rm $GN_FILE
 
 #Set geonetwork data dir
 COPY ./docker-entrypoint.sh /entrypoint.sh

--- a/3.2.0/docker-entrypoint.sh
+++ b/3.2.0/docker-entrypoint.sh
@@ -3,13 +3,10 @@ set -e
 
 if [ "$1" = 'catalina.sh' ]; then
 
- mkdir -p "$DATA_DIR"
+	mkdir -p "$DATA_DIR"
 
- #Set geonetwork data dir
- sed -i '$d' /usr/local/tomcat/bin/setclasspath.sh
- echo "CATALINA_OPTS=\"\$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR\"" >> /usr/local/tomcat/bin/setclasspath.sh
- echo "fi" >> /usr/local/tomcat/bin/setclasspath.sh
-
+	#Set geonetwork data dir
+	export CATALINA_OPTS="$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR"
 fi
 
 exec "$@"

--- a/3.2.0/postgres/Dockerfile
+++ b/3.2.0/postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM geonetwork:3.2.0
 
 RUN apt-get update && apt-get install -y postgresql-client && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 #Set PostgreSQL as default GN DB
 RUN sed -i -e 's#<import resource="../config-db/h2.xml"/>#<!--<import resource="../config-db/h2.xml"/> -->#g' $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-node/srv.xml
@@ -12,3 +12,5 @@ COPY ./jdbc.properties $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-db/jdbc.
 #Initializing database & connection string for GN
 COPY ./docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["catalina.sh", "run"]

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eo pipefail
+
+cd "$(dirname "$BASH_SOURCE")"
+
+versions=( "$@" )
+if [ ${#versions[@]} -eq 0 ]; then
+	versions=( */ )
+fi
+versions=( "${versions[@]%/}" )
+
+for version in "${versions[@]}"; do
+	md5="$(curl -fsSL --retry 5 "https://sourceforge.net/projects/geonetwork/files/GeoNetwork_opensource/v${version}/geonetwork.war.MD5/download")"
+
+	sed -ri \
+		-e 's/^(ENV GN_VERSION) .*/\1 '"$version"'/' \
+		-e 's/^(ENV GN_DOWNLOAD_MD5) .*/\1 '"$md5"'/' \
+		-e 's/^(FROM geonetwork):.*/\1:'"$version"'/' \
+		"$version/Dockerfile" "$version/postgres/Dockerfile"
+done


### PR DESCRIPTION
- adjust `tomcat:8.0` to `tomcat:8.0-jre7` (to be explicit about "Tomcat 8.0" and "Java 7")
- adjust `tomcat:8-jre8` to `tomcat:8.0-jre8` so that if/when Tomcat 8.5 becomes stable, we don't unexpectedly switch (so that switching Tomcat release tracks becomes a concious choice instead)
- add back `GN_DOWNLOAD_MD5`, and a simple `update.sh` script for updating the value (when `geonetwork.war` is updated, this value will need to be updated so that we downstream know to rebuild, and so that the cache busts naturally)
  - usage: `./update.sh` (to update all versions) or `./update.sh 3.2.0 3.0.5` to update one or more versions
- combine `RUN` lines into a single line so that the `.war` file is completely removed, resulting in a smaller overall image
- use the more reliable `export CATALINA_OPTS="$CATALINA_OPTS ..."` in the entrypoint rather than doing a fragile `sed` on a Tomcat startup file
- small adjustments to `postgres/docker-entrypoint.sh` to make it more reliable at updating configuration and to allow it to run more than once in a single container safely (`docker restart my-geonetwork`, for example)
- recreate the proper contents of `3.0.4/postgres/docker-entrypoint.sh` which appear to have been accidentally overwritten in a previous commit
- make whitespace consistent within each file

I'm happy to expound on any of these changes or rebase/amend/adjust/discuss as desired. :+1: :heart:

(I figured a PR would be an easier way to get my exact meaning across for all of these.)