### PR TITLE
Removing deprecated parameters in JRE8

### DIFF
--- a/3.2.0/Dockerfile
+++ b/3.2.0/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.0-jre8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
-ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC"
+ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:+UseConcMarkSweepGC"
 
 #Environment variables
 ENV GN_VERSION 3.2.0

--- a/3.2.1/Dockerfile
+++ b/3.2.1/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.0-jre8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
-ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -server -Xms512m -Xmx2024m -XX:NewSize=512m -XX:MaxNewSize=1024m -XX:PermSize=512m -XX:MaxPermSize=1024m -XX:+UseConcMarkSweepGC"
+ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -server -Xms512m -Xmx2024m -XX:NewSize=512m -XX:MaxNewSize=1024m -XX:+UseConcMarkSweepGC"
 
 #Environment variables
 ENV GN_VERSION 3.2.1

--- a/3.2.2/Dockerfile
+++ b/3.2.2/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.0-jre8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
-ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -server -Xms512m -Xmx2024m -XX:NewSize=512m -XX:MaxNewSize=1024m -XX:PermSize=512m -XX:MaxPermSize=1024m -XX:+UseConcMarkSweepGC"
+ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -server -Xms512m -Xmx2024m -XX:NewSize=512m -XX:MaxNewSize=1024m -XX:+UseConcMarkSweepGC"
 
 #Environment variables
 ENV GN_VERSION 3.2.2


### PR DESCRIPTION
The permanent generation disappeared in Java 8, removing useless JVM variables, which cause the following messages at startup:

```
OpenJDK 64-Bit Server VM warning: ignoring option PermSize=512m; support was removed in 8.0
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=1024m; support was removed in 8.0
```
