### PR TITLE
Update "generate-stackbrew-library.sh" to include "Architectures:"

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -8,7 +8,7 @@ declare -A aliases=(
 )
 
 # builds to exclude from tagging
-dirExclude=([3.0.5],[3.2.0],[3.2.1],[3.4.0],[3.4.1],[3.4.2])
+dirExclude=([3.0.5],[3.2.0],[3.2.1],[3.2.2],[3.4.0],[3.4.1],[3.4.2])
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink "$BASH_SOURCE")")"
@@ -43,6 +43,7 @@ cat <<-EOH
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 EOH
 
 # prints "$2$1$3$1...$N"


### PR DESCRIPTION
This is for https://github.com/docker-library/official-images/pull/4724.

I've put `Architectures:` in the global section, which means it applies to all subsequent `Tags:` entries (unless they specify their own, which would then be an override).

This might have to change with future versions of `geonetwork` or if `tomcat:8.0-jre8`'s list changes, but it's fine for now (and simple to implement). :+1: