### PR TITLE
Update base image to tomcat:8.5-jre8

### DIFF
--- a/3.4.4/Dockerfile
+++ b/3.4.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jre8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data


### PR DESCRIPTION
`tomcat:8.0-jre8` is not available anymore at Dockerhub. This PR upgrade the base image to Tomcat 8.5