### PR TITLE
Bring docker-compose.yml to life, 1 master and 1 slave.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+HTTP_PROXY=
+HTTPS_PROXY=
+NO_PROXY=127.0.0.1,localhost
+
+MAVEN_OPTS=-Dhttp.proxyHost= -Dhttp.proxyPort= -Dhttps.proxyHost= -Dhttps.proxyPort=
+
+GIT_CLONE=--branch master --recursive --single-branch https://github.com/geonetwork/core-geonetwork.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-geonetwork
+/geonetwork
+/3.7.0-dev/m2repo_gn/*
+!/3.7.0-dev/m2repo_gn/.gitkeep
+/volume_*

--- a/3.7.0-dev/Dockerfile
+++ b/3.7.0-dev/Dockerfile
@@ -1,0 +1,97 @@
+FROM maven:3.6.1-jdk-8 AS lala
+LABEL maintainer="Ob Rzwo <obr2pd@gmail.com>"
+ARG HTTP_PROXY
+ENV HTTP_PROXY ${HTTP_PROXY}
+ARG HTTPS_PROXY
+ENV HTTPS_PROXY ${HTTPS_PROXY}
+ARG NO_PROXY
+ENV NO_PROXY ${NO_PROXY}
+ENV http_proxy ${HTTP_PROXY}
+ENV https_proxy ${HTTPS_PROXY}
+ENV no_proxy ${NO_PROXY}
+ARG GIT_CLONE
+ENV GIT_CLONE ${GIT_CLONE}
+ARG MAVEN_OPTS
+ENV MAVEN_OPTS ${MAVEN_OPTS}
+WORKDIR /opt/
+RUN git clone ${GIT_CLONE} core-geonetwork
+WORKDIR /opt/core-geonetwork/
+RUN sed -i -e 's|slave.masterURL=https://..../geonetwork|slave.masterURL=http://geonetworkmaster:8080/geonetwork|' ./slave/src/main/resources/slave.properties
+# Use cached Maven stuff, if you have:
+WORKDIR /root/.m2/
+COPY ./m2repo_gn/ ./
+WORKDIR /opt/core-geonetwork/
+ARG MASTER_OR_SLAVE
+ENV MASTER_OR_SLAVE ${MASTER_OR_SLAVE}
+# Download Maven stuff step by step:
+RUN mvn                                --projects=common dependency:go-offline
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common package install
+# RUN ls -al /root/.m2/repository/org/geonetwork-opensource/common/3.7.0-SNAPSHOT/
+RUN mvn                                --projects=common,cachingxslt dependency:go-offline
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt package install
+RUN mvn                                --projects=common,cachingxslt,sde dependency:go-offline
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde package install
+RUN mvn                                --projects=common,cachingxslt,sde,domain dependency:go-offline
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain package install
+RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh dependency:go-offline
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh package install
+RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events dependency:go-offline
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events package install
+# At this point you cannot continue like this, because schema-iso19139 is needed. Create the rest at once, see below.
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es,release dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es,release package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es,release,workers dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es,release,workers package install
+# RUN mvn                                --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es,release,workers,messaging dependency:go-offline
+# RUN mvn -DskipTests ${MASTER_OR_SLAVE} --projects=common,cachingxslt,sde,domain,oaipmh,events,core,schemas,csw-server,harvesters,healthmonitor,services,wro4j,inspire-atom,doi,es,release,workers,messaging package install
+RUN mvn -DskipTests ${MASTER_OR_SLAVE} package install
+
+FROM tomcat:8.5.40-jre8
+# Credits to: Jeroen Ticheler <jeroen.ticheler@geocat.net>
+LABEL maintainer="Ob Rzwo <obr2pd@gmail.com>"
+ARG HTTP_PROXY
+ENV HTTP_PROXY ${HTTP_PROXY}
+ARG HTTPS_PROXY
+ENV HTTPS_PROXY ${HTTPS_PROXY}
+ARG NO_PROXY
+ENV NO_PROXY ${NO_PROXY}
+ENV http_proxy ${HTTP_PROXY}
+ENV https_proxy ${HTTPS_PROXY}
+ENV no_proxy ${NO_PROXY}
+COPY apt.conf /etc/apt/
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update \
+  && apt-get install -y postgresql-client \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /usr/local/tomcat/webapps/
+COPY --from=lala /opt/core-geonetwork/web/target/geonetwork.war ./
+RUN mkdir -p ./geonetwork/ \
+  && unzip -d ./geonetwork/ ./geonetwork.war
+RUN sed -i -e 's|<session-timeout>35</session-timeout>|<session-timeout>999</session-timeout>|' ./geonetwork/WEB-INF/web.xml
+RUN sed -i -e 's#<import resource="../config-db/h2.xml"/>#<!--<import resource="../config-db/h2.xml"/> -->#g' ./geonetwork/WEB-INF/config-node/srv.xml \
+  && sed -i -e 's#<!--<import resource="../config-db/postgres.xml"/>-->#<import resource="../config-db/postgres.xml"/>#g' ./geonetwork/WEB-INF/config-node/srv.xml
+COPY ./jdbc.properties ./geonetwork/WEB-INF/config-db/jdbc.properties
+COPY ./docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["catalina.sh", "run"]
+EXPOSE 8080

--- a/3.7.0-dev/Dockerfile
+++ b/3.7.0-dev/Dockerfile
@@ -16,6 +16,7 @@ ENV MAVEN_OPTS ${MAVEN_OPTS}
 WORKDIR /opt/
 RUN git clone ${GIT_CLONE} core-geonetwork
 WORKDIR /opt/core-geonetwork/
+# RUN git checkout -b lele a650e81 && git reset --hard && git log -n 2
 RUN sed -i -e 's|slave.masterURL=https://..../geonetwork|slave.masterURL=http://geonetworkmaster:8080/geonetwork|' ./slave/src/main/resources/slave.properties
 # Use cached Maven stuff, if you have:
 WORKDIR /root/.m2/

--- a/3.7.0-dev/apt.conf
+++ b/3.7.0-dev/apt.conf
@@ -1,0 +1,2 @@
+Acquire::http::Proxy "";
+Acquire::https::Proxy "";

--- a/3.7.0-dev/docker-entrypoint.sh
+++ b/3.7.0-dev/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = 'catalina.sh' ]; then
+
+	mkdir -p "$DATA_DIR"
+
+	#Set geonetwork data dir
+	export CATALINA_OPTS="$CATALINA_OPTS -Dgeonetwork.dir=$DATA_DIR"
+
+	#Setting host (use $POSTGRES_DB_HOST if it's set, otherwise use "postgres")
+	db_host="${POSTGRES_DB_HOST:-postgres}"
+	echo "db host: $db_host"
+
+	#Setting port
+	db_port="${POSTGRES_DB_PORT:-5432}"
+	echo "db port: $db_port"
+
+	if [ -z "$POSTGRES_DB_USERNAME" ] || [ -z "$POSTGRES_DB_PASSWORD" ]; then
+		echo >&2 "you must set POSTGRES_DB_USERNAME and POSTGRES_DB_PASSWORD"
+		exit 1
+	fi
+
+	db_admin="admin"
+	db_gn="geonetwork"
+
+	#Create databases, if they do not exist yet (http://stackoverflow.com/a/36591842/433558)
+	echo  "$db_host:$db_port:*:$POSTGRES_DB_USERNAME:$POSTGRES_DB_PASSWORD" > ~/.pgpass
+	chmod 0600 ~/.pgpass
+	for db_name in "$db_admin" "$db_gn"; do
+		if psql -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -tqc "SELECT 1 FROM pg_database WHERE datname = '$db_name'" | grep -q 1; then
+			echo "database '$db_name' exists; skipping createdb"
+		else
+			createdb -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -O "$POSTGRES_DB_USERNAME" "$db_name"
+		fi
+	done
+	rm ~/.pgpass
+
+	#Write connection string for GN
+	sed -ri '/^jdbc[.](username|password|database|host|port)=/d' "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.username=$POSTGRES_DB_USERNAME" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.password=$POSTGRES_DB_PASSWORD" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.database=$db_gn" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.host=$db_host" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+	echo "jdbc.port=$db_port" >> "$CATALINA_HOME"/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+
+	#Fixing an hardcoded port on the connection string (bug fixed on development branch)
+	sed -i -e 's#5432#${jdbc.port}#g' $CATALINA_HOME/webapps/geonetwork/WEB-INF/config-db/postgres.xml
+fi
+
+exec "$@"

--- a/3.7.0-dev/jdbc.properties
+++ b/3.7.0-dev/jdbc.properties
@@ -1,0 +1,17 @@
+jdbc.basic.removeAbandoned=true
+jdbc.basic.removeAbandonedTimeout=120
+jdbc.basic.logAbandoned=true
+jdbc.basic.maxActive=33
+jdbc.basic.maxIdle=${jdbc.basic.maxActive}
+jdbc.basic.initialSize=${jdbc.basic.maxActive}
+jdbc.basic.maxWait=200
+jdbc.basic.testOnBorrow=true
+jdbc.basic.timeBetweenEvictionRunsMillis=10000
+jdbc.basic.minEvictableIdleTimeMillis=1800000
+jdbc.basic.testWhileIdle=true
+jdbc.basic.numTestsPerEvictionRun=3
+jdbc.basic.poolPreparedStatements=true
+jdbc.basic.maxOpenPreparedStatements=1200
+jdbc.basic.validationQuery=SELECT 1
+jdbc.basic.defaultReadOnly=false
+jdbc.basic.defaultAutoCommit=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - POSTGRES_DB_USERNAME=geonetwork
       - POSTGRES_DB_PASSWORD=********
       - POSTGRES_DB_HOST=dbmaster
-    image: obr2pd/geonetworkmaster:5c600fc
+    image: obr2pd/geonetworkmaster:a650e81
     logging:
       driver: "json-file" 
       options:
@@ -83,7 +83,7 @@ services:
       - POSTGRES_DB_USERNAME=geonetwork
       - POSTGRES_DB_PASSWORD=********
       - POSTGRES_DB_HOST=dbslave
-    image: obr2pd/geonetworkslave:5c600fc
+    image: obr2pd/geonetworkslave:a650e81
     logging:
       driver: "json-file" 
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,100 @@
+version: "3.7"
+services:
+  dbmaster:
+    environment:
+      - POSTGRES_USER=geonetwork
+      - POSTGRES_PASSWORD=********
+      - POSTGRES_DB=geonetwork
+    image: mdillon/postgis:9.6
+    logging:
+      driver: "json-file" 
+      options:
+        max-size: "10m" 
+        max-file: "10" 
+    networks:
+      gn:
+    restart: always
+    volumes:
+      - ./volume_db_master/:/var/lib/postgresql/data/
+  dbslave:
+    environment:
+      - POSTGRES_USER=geonetwork
+      - POSTGRES_PASSWORD=********
+      - POSTGRES_DB=geonetwork
+    image: mdillon/postgis:9.6
+    logging:
+      driver: "json-file" 
+      options:
+        max-size: "10m" 
+        max-file: "10" 
+    networks:
+      gn:
+    restart: always
+    volumes:
+      - ./volume_db_slave/:/var/lib/postgresql/data/
+  geonetworkmaster:
+    build:
+      args:
+        GIT_CLONE: ${GIT_CLONE}
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTPS_PROXY}
+        MASTER_OR_SLAVE:
+        MAVEN_OPTS: ${MAVEN_OPTS}
+        NO_PROXY: ${NO_PROXY}
+      context: ./3.7.0-dev/
+    depends_on:
+      - dbmaster
+    env_file: .env  # must be in the same folder as docker-compose.yml!!!
+    environment:
+      - JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -server -Xms512m -Xmx6g -XX:NewSize=512m -XX:MaxNewSize=1024m -XX:+UseConcMarkSweepGC"
+      - DATA_DIR=/var/lib/geonetwork_data
+      - POSTGRES_DB_USERNAME=geonetwork
+      - POSTGRES_DB_PASSWORD=********
+      - POSTGRES_DB_HOST=dbmaster
+    image: obr2pd/geonetworkmaster:5c600fc
+    logging:
+      driver: "json-file" 
+      options:
+        max-size: "10m" 
+        max-file: "10" 
+    networks:
+      gn:
+    ports:
+      - 8080:8080
+    restart: always
+    volumes:
+      - ./volume_geonetwork_master/:/var/lib/geonetwork_data/
+  geonetworkslave:
+    build:
+      args:
+        GIT_CLONE: ${GIT_CLONE}
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTPS_PROXY}
+        MASTER_OR_SLAVE: -P slave
+        MAVEN_OPTS: ${MAVEN_OPTS}
+        NO_PROXY: ${NO_PROXY}
+      context: ./3.7.0-dev/
+    depends_on:
+      - dbslave
+    env_file: .env  # must be in the same folder as docker-compose.yml!!!
+    environment:
+      - JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -server -Xms512m -Xmx6g -XX:NewSize=512m -XX:MaxNewSize=1024m -XX:+UseConcMarkSweepGC"
+      - DATA_DIR=/var/lib/geonetwork_data
+      - POSTGRES_DB_USERNAME=geonetwork
+      - POSTGRES_DB_PASSWORD=********
+      - POSTGRES_DB_HOST=dbslave
+    image: obr2pd/geonetworkslave:5c600fc
+    logging:
+      driver: "json-file" 
+      options:
+        max-size: "10m" 
+        max-file: "10" 
+    networks:
+      gn:
+    ports:
+      - 4567:8080
+    restart: always
+    volumes:
+      - ./volume_geonetwork_slave/:/var/lib/geonetwork_data/
+networks:
+  gn:


### PR DESCRIPTION
Hello, first I wanted to do this PR in the main repo core-geonetwork: https://github.com/geonetwork/core-geonetwork/pull/3775. At PascalLike's suggestion, now here.

(I think it makes sense to follow up on the documentary, too: https://github.com/docker-library/docs/blob/master/geonetwork/README.md. Let's see when I can do this.)

I brought in Docker Compose with this Commit. I also removed the postgres folder (the `restart: always` guarantees that the database does not have to be booted when Geonetwork starts (again)!), added HTTP proxy support, and added construction of the war file via Maven.

It can do no harm to change the password in the docker-compose.yml file.

A master and a slave can be created with:

```
git clone --branch master --single-branch https://github.com/bor8/docker-geonetwork.git
cd docker-geonetwork
sudo docker-compose build
sudo docker-compose up -d
```

(The sudo is not necessary if you have configured your system correctly: `sudo usermod -aG docker <USERNAME>` plus logout and login.)

It takes a while until the master and slave are built. Especially downloading the Maven files takes years.

Alternatively, if you want it to go faster and you don't want to build it yourself:

```
git clone --branch master --single-branch https://github.com/bor8/docker-geonetwork.git
cd docker-geonetwork
sudo docker-compose pull
sudo docker-compose up -d
```

If everything worked out, you can open master with http://localhost:8080/geonetwork/ and slave with http://localhost:4567/geonetwork/.

The slave automatically retrieves the latest data from the master every half hour.

Tested on Docker 18.09.5 and Docker-Compose 1.24.0 without HTTP proxy (but if necessary you only have to modify the .env and apt.conf files).
