### PR TITLE
Update Tomcat base image

### DIFF
--- a/3.0.5/Dockerfile
+++ b/3.0.5/Dockerfile
@@ -1,8 +1,8 @@
-FROM tomcat:8.0-jre7
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
-ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC"
+ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx1024M -Xss2M -XX:+UseConcMarkSweepGC"
 
 #Environment variables
 ENV GN_VERSION 3.0.5

--- a/3.2.0/Dockerfile
+++ b/3.2.0/Dockerfile
@@ -1,8 +1,8 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data
-ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx512M -Xss2M -XX:+UseConcMarkSweepGC"
+ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx1024M -Xss2M -XX:+UseConcMarkSweepGC"
 
 #Environment variables
 ENV GN_VERSION 3.2.0

--- a/3.2.1/Dockerfile
+++ b/3.2.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.2.2/Dockerfile
+++ b/3.2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.4.0/Dockerfile
+++ b/3.4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.4.1/Dockerfile
+++ b/3.4.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.4.2/Dockerfile
+++ b/3.4.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.4.3/Dockerfile
+++ b/3.4.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.4.4/Dockerfile
+++ b/3.4.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data

--- a/3.6.0/Dockerfile
+++ b/3.6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5-jre8
+FROM tomcat:8.5-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data


### PR DESCRIPTION
Due to https://github.com/docker-library/tomcat/pull/158 jre8 based images
are no longer available. Use jdk8 based images instead.