### PR TITLE
Fix for excess database creation in geonetwork-postgres entrypoint

### DIFF
--- a/3.8.1/postgres/docker-entrypoint.sh
+++ b/3.8.1/postgres/docker-entrypoint.sh
@@ -26,11 +26,11 @@ if [ "$1" = 'catalina.sh' ]; then
 	#Create databases, if they do not exist yet (http://stackoverflow.com/a/36591842/433558)
 	echo  "$db_host:$db_port:*:$POSTGRES_DB_USERNAME:$POSTGRES_DB_PASSWORD" > ~/.pgpass
 	chmod 0600 ~/.pgpass
-    if psql -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -tqc "SELECT 1 FROM pg_database WHERE datname = '$db_gn'" | grep -q 1; then
-        echo "database '$db_gn' exists; skipping createdb"
-    else
-        createdb -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -O "$POSTGRES_DB_USERNAME" "$db_gn"
-    fi
+        if psql -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -tqc "SELECT 1 FROM pg_database WHERE datname = '$db_gn'" | grep -q 1; then
+            echo "database '$db_gn' exists; skipping createdb"
+        else
+            createdb -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -O "$POSTGRES_DB_USERNAME" "$db_gn"
+        fi
 	rm ~/.pgpass
 
 	#Write connection string for GN

--- a/3.8.1/postgres/docker-entrypoint.sh
+++ b/3.8.1/postgres/docker-entrypoint.sh
@@ -21,19 +21,16 @@ if [ "$1" = 'catalina.sh' ]; then
 		exit 1
 	fi
 
-	db_admin="admin"
-	db_gn="geonetwork"
+	db_gn="${POSTGRES_DB_NAME:-geonetwork}"
 
 	#Create databases, if they do not exist yet (http://stackoverflow.com/a/36591842/433558)
 	echo  "$db_host:$db_port:*:$POSTGRES_DB_USERNAME:$POSTGRES_DB_PASSWORD" > ~/.pgpass
 	chmod 0600 ~/.pgpass
-	for db_name in "$db_admin" "$db_gn"; do
-		if psql -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -tqc "SELECT 1 FROM pg_database WHERE datname = '$db_name'" | grep -q 1; then
-			echo "database '$db_name' exists; skipping createdb"
-		else
-			createdb -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -O "$POSTGRES_DB_USERNAME" "$db_name"
-		fi
-	done
+    if psql -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -tqc "SELECT 1 FROM pg_database WHERE datname = '$db_gn'" | grep -q 1; then
+        echo "database '$db_gn' exists; skipping createdb"
+    else
+        createdb -h "$db_host" -U "$POSTGRES_DB_USERNAME" -p "$db_port" -O "$POSTGRES_DB_USERNAME" "$db_gn"
+    fi
 	rm ~/.pgpass
 
 	#Write connection string for GN


### PR DESCRIPTION
* Corrected entrypoint for geonetwork-postgres (3.8.1) so it does not create or check for existence of 'admin' database which is not used.
* Added a possibility to name a geonetwork database using environmental variable POSTGRES_DB_NAME. If it is not set than default name 'geonetwork' is used.
