### PR TITLE
WIP: adds 3.11.snapshot + initial keycloak configuration

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,0 +1,19 @@
+FROM tomcat:8.5-jre8
+
+MAINTAINER pvangenuchten <paul@geocat.net>
+
+WORKDIR $CATALINA_HOME/webapps
+
+ENV GN_FILE geonetwork-3.11.0-SNAPSHOT-2021-01-04.war
+
+RUN mv $CATALINA_HOME/webapps/ROOT $CATALINA_HOME/webapps/TOMCAT && \
+    mkdir $CATALINA_HOME/webapps/ROOT && \ 
+    cd $CATALINA_HOME/webapps/ROOT && \
+    curl -fSL -o geonetwork.war \
+    http://nightlybuild.geonetwork-opensource.org/master/${GN_FILE} && \
+    unzip -q geonetwork.war && \
+    rm geonetwork.war
+
+CMD ["catalina.sh", "run"]
+
+

--- a/master/keycloak/Dockerfile
+++ b/master/keycloak/Dockerfile
@@ -1,0 +1,21 @@
+FROM tomcat:8.5-jre8
+
+MAINTAINER pvangenuchten <paul@geocat.net>
+
+WORKDIR $CATALINA_HOME/webapps
+
+ENV GN_FILE geonetwork-3.11.0-SNAPSHOT-2021-01-04.war
+
+RUN mv $CATALINA_HOME/webapps/ROOT $CATALINA_HOME/webapps/TOMCAT && \
+    mkdir $CATALINA_HOME/webapps/ROOT && \ 
+    cd $CATALINA_HOME/webapps/ROOT && \
+    curl -fSL -o geonetwork.war \
+    http://nightlybuild.geonetwork-opensource.org/master/${GN_FILE} && \
+    unzip -q geonetwork.war && \
+    rm geonetwork.war
+
+COPY ./config-security.xml $CATALINA_HOME/webapps/ROOT/WEB-INF
+
+CMD ["catalina.sh", "run"]
+
+

--- a/master/keycloak/config-security.xml
+++ b/master/keycloak/config-security.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<beans
+  xmlns:ctx="http://www.springframework.org/schema/context"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+          http://www.springframework.org/schema/context
+          http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+  xmlns="http://www.springframework.org/schema/beans">
+  <!-- <sec:debug/> -->
+  <import resource="config-security-core.xml"/>
+  <import resource="config-security-mapping.xml"/>
+  <import resource="config-security-keycloak.xml"/>
+  <!--<import resource="config-security-ldap.xml"/>-->
+  <!--<import resource="config-security-ldap-recursive.xml"/>-->
+  <!-- <import resource="config-security-ecas.xml"/> -->
+  <!--<import resource="config-security-cas.xml"/>-->
+  <!--<import resource="config-security-cas-ldap.xml"/>-->
+  <!-- <import resource="config-security-cas-database.xml"/> -->
+  <!-- <import resource="config-security-shibboleth.xml"/>  -->
+  <ctx:property-placeholder location="WEB-INF/config-security/config-security.properties"
+                            file-encoding="UTF-8" ignore-unresolvable="true" order="100"/>
+
+</beans>

--- a/master/keycloak/docker-compose.yml
+++ b/master/keycloak/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.1'
+
+volumes:
+  geonetwork:
+  keycloak:
+
+services:
+  
+  geonetwork:
+    image: geonetwork:3.11.SNAPSHOT
+    restart: always
+    ports:
+      - 443:8443
+    environment:
+      DATA_DIR: '/catalogue-data'
+      KEYCLOAK_AUTH_SERVER_URL: 'http://192.168.99.102:82/auth'
+      KEYCLOAK_REALM: 'myrealm'
+      KEYCLOAK_RESOURCE: 'myclient'
+      KEYCLOAK_SECRET: 'mysecret'
+      KEYCLOAK_DISABLE_TRUST_MANAGER: 'true'
+      JAVA_OPTS: >
+        -Dgeonetwork.data.dir=/catalogue-data
+    volumes:
+      - geonetwork:/catalogue-data
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:12.0.1
+    restart: always
+    ports:
+      - 82:8080
+    environment:
+      KEYCLOAK_USER: 'admin'
+      KEYCLOAK_PASSWORD: 'admin'
+    volumes:
+      - keycloak:/data


### PR DESCRIPTION
i'm trying to set up a docker-compose with keycloak docker as described in https://github.com/geonetwork/core-geonetwork/pull/4931
it requires latest 3.11 snapshot, which has this PR merged

items pending
- [ ] setup keycloak (probably needs to put h2 db configuration on mounted volume)
- [ ] setup geonetwork so it uses keycloak
- [ ] can we add some default configuration to keycloak, so it loads in a automated way
- [ ] wait for 3.12.0 release, or consider a mechanism to always take latest nightly