### PR TITLE
Use images based on Temurin JDK

### DIFF
--- a/4.0.6/Dockerfile
+++ b/4.0.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9-jre8-openjdk
+FROM jetty:9-jdk8
 
 ENV DATA_DIR /catalogue-data
 ENV JAVA_OPTS -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF \
@@ -11,7 +11,9 @@ ENV JAVA_OPTS -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF \
 
 USER root
 RUN apt-get -y update && \
-    apt-get -y install curl && \
+    apt-get -y install \
+        curl \
+        unzip && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /${DATA_DIR} && \
     chown -R jetty:jetty ${DATA_DIR} && \

--- a/4.0.6/Dockerfile.local
+++ b/4.0.6/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM jetty:9-jre8-openjdk
+FROM jetty:9-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV GN_VERSION 4.0.6
@@ -13,7 +13,11 @@ ENV JAVA_OPTS -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF \
         -Dgeonetwork.schema.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/schema_plugins 
 
 USER root
-RUN mkdir -p /catalogue-data && \
+RUN apt-get -y update && \
+    apt-get -y install \
+        unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /catalogue-data && \
     chown -R jetty:jetty /catalogue-data && \
     mkdir -p /var/lib/jetty/webapps/geonetwork && \
     chown -R jetty:jetty /var/lib/jetty/webapps/geonetwork

--- a/4.2.0/Dockerfile
+++ b/4.2.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9-jre8-openjdk
+FROM jetty:9-jdk8
 
 ENV DATA_DIR /catalogue-data
 ENV JAVA_OPTS -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF \
@@ -11,7 +11,9 @@ ENV JAVA_OPTS -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF \
 
 USER root
 RUN apt-get -y update && \
-    apt-get -y install curl && \
+    apt-get -y install \
+      curl \
+      unzip && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /${DATA_DIR} && \
     chown -R jetty:jetty ${DATA_DIR} && \

--- a/4.2.0/Dockerfile.local
+++ b/4.2.0/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM jetty:9-jre8-openjdk
+FROM jetty:9-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV GN_VERSION 4.2.0
@@ -13,10 +13,15 @@ ENV JAVA_OPTS -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF \
         -Dgeonetwork.schema.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/schema_plugins 
 
 USER root
-RUN mkdir -p /catalogue-data && \
+RUN apt-get -y update && \
+    apt-get -y install unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /catalogue-data && \
     chown -R jetty:jetty /catalogue-data && \
     mkdir -p /var/lib/jetty/webapps/geonetwork && \
     chown -R jetty:jetty /var/lib/jetty/webapps/geonetwork
+
+     
 
 USER jetty
 COPY geonetwork.war /var/lib/jetty/webapps/geonetwork/geonetwork.war


### PR DESCRIPTION
As indicated in https://github.com/docker-library/official-images/pull/12851#issuecomment-1194480196 OpenJDK image will no receive further updates.
GeoNetwork 4 was using a Jetty image based on OpenJDK. This commit changes that to a Jetty image that uses Temurin JDK.
