### PR TITLE
ES auth sed command fix

### DIFF
--- a/4.2.2/docker-entrypoint.sh
+++ b/4.2.2/docker-entrypoint.sh
@@ -46,11 +46,11 @@ if [[ "$1" = jetty.sh ]] || [[ $(expr "$*" : 'java .*/start\.jar.*$') != 0 ]]; t
     fi
 
     if [ "${ES_USERNAME}" != "" ] ; then
-        sed -i "s#es.username=#es.username=${ES_USERNAME}#" "${JETTY_BASE}/webapps/geonetwork/WEB-INF/config.properties" ;
+        sed -i "s/es.username=.*/es.username=${ES_USERNAME}/" "${JETTY_BASE}/webapps/geonetwork/WEB-INF/config.properties" ;
     fi
 
     if [ "${ES_PASSWORD}" != "" ] ; then
-        sed -i "s#es.password=#es.password=${ES_PASSWORD}#" "${JETTY_BASE}/webapps/geonetwork/WEB-INF/config.properties" ;
+        sed -i "s/es.password=.*/es.password=${ES_PASSWORD}/" "${JETTY_BASE}/webapps/geonetwork/WEB-INF/config.properties" ;
     fi
 
     if [ -n "${KB_URL}" ] && [ "$KB_URL" != "http://localhost:5601" ]; then


### PR DESCRIPTION
I ran into some issues properly setting the ES username and password in the *properties.config* through the entrypoint script. The existing code was duplicating the username and password values. These updated `sed` commands fix that issue for me. I didn't look to see if this issue exists in previous versions of geonetwork, but I can make the changes if this issue exists there too. 