### PR TITLE
Update generate-stackbrew-library.sh with URL ending with .git

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -77,7 +77,7 @@ cat <<-EOH
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
 	     Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
-GitRepo: https://github.com/geonetwork/docker-geonetwork
+GitRepo: https://github.com/geonetwork/docker-geonetwork.git
 GitFetch: refs/heads/main
 EOH
 


### PR DESCRIPTION
As required by https://github.com/docker-library/official-images/pull/16082 the Git repo URL must end with .git.