### PR TITLE
Use Tomcat 9 instead Tomcat 8.5

### DIFF
--- a/3.12.9/Dockerfile
+++ b/3.12.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5-jdk8
+FROM tomcat:9-jdk8
 
 ENV GN_FILE geonetwork.war
 ENV DATA_DIR=$CATALINA_HOME/webapps/geonetwork/WEB-INF/data


### PR DESCRIPTION
Tomcat 8.5 reached end-of-live on 2024-03-31 and the upstream Tomcat
official docker image will not be updated anymore. To keep maintaining
the GeoNetwork 3.12 image in the official repo Docker team has asked to
update Tomcat or to remove the version from the list. We are updating
to Tomcat 9.

https://github.com/docker-library/official-images/pull/16518
