### PR TITLE
point to 4.4.7 tag in docker-compose.yml

### DIFF
--- a/4.4.7/docker-compose.yml
+++ b/4.4.7/docker-compose.yml
@@ -41,7 +41,7 @@ x-geonetwork-environment:
 
 x-service-geonetwork:
   &default-service-geonetwork
-  image: geonetwork:4.4.6
+  image: geonetwork:4.4.7
   healthcheck:
     test: "curl http://localhost:8080/"
     interval: 5s


### PR DESCRIPTION
- 4.4.7 release incorrectly points to `image: geonetwork:4.4.6`